### PR TITLE
Support SUMMATION_WATTS in Home Assistant discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Device status is tracked (```online``` and ```offline```) on topic ```MQTT_TOPIC
 Bridge status is tracked (```online``` and ```offline```) on topic```MQTT_TOPIC/bridge/status``` (retained)
 
 Current supported messages:<br>
-* Instantanious Demand (in Watts): ```MQTT_TOPIC/meter/demand```
+* Instantaneous Demand (in Watts): ```MQTT_TOPIC/meter/demand```
 * Summation Delivered (rounded to neaest kWh or Wh): ```MQTT_TOPIC/meter/delivered```
 * Summation Received (rounded to nearest kWh or Wh): ```MQTT_TOPIC/meter/received```
 * Price / kWh (set by utility or manually entered): ```MQTT_TOPIC/pricing/price```

--- a/hadiscovery.js
+++ b/hadiscovery.js
@@ -1,6 +1,10 @@
 var messageset = {}
 
 function buildDiscovery(topic_base) {
+	regex = new RegExp('^true$', 'i')
+	const hires = regex.test(process.env.SUMMATION_WATTS) ? true : false
+	const summationunit = hires ? 'Wh' : 'kWh'
+
 	const eagle_device = {
 	  "payload_available": "online",
 	  "payload_not_available": "offline",
@@ -51,7 +55,7 @@ function buildDiscovery(topic_base) {
 	  ...eagle_device,
 	  "name": "Rainforest Eagle Energy Delivered",
 	  "unique_id": "rfeagle_delivered",
-	  "unit_of_measurement": "kWh",
+	  "unit_of_measurement": summationunit,
 	  "state_class": "total_increasing",
 	  "device_class": "energy"
 	}
@@ -62,7 +66,7 @@ function buildDiscovery(topic_base) {
 	  ...eagle_device,
 	  "name": "Rainforest Eagle Energy Received",
 	  "unique_id": "rfeagle_received",
-	  "unit_of_measurement": "kWh",
+	  "unit_of_measurement": summationunit,
 	  "device_class": "energy"  
 	}
 	eagle_meter_received_message["state_topic"] = topic_base + "/meter/received"


### PR DESCRIPTION
Noticed the Home Assistant MQTT discovery was always sending "kWh" as the unit for delivered and received, even when SUMMATION_WATTS=true.

Copied code over to send 'Wh' when applicable. Tested with SUMMATION_WATTS=true/false to confirm the right unit was being sent.

+ minor typo fix in README.